### PR TITLE
Migrate aws_c_common, aws_c_http & aws_c_io

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,9 +1,9 @@
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,11 +1,11 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,9 +1,9 @@
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/migrations/aws_c_common089.yaml
+++ b/.ci_support/migrations/aws_c_common089.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_common:
+- 0.8.9
+migrator_ts: 1673680911.2455108

--- a/.ci_support/migrations/aws_c_http073.yaml
+++ b/.ci_support/migrations/aws_c_http073.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  automerge: true
+aws_c_http:
+- 0.7.3
+migrator_ts: 1675172490.116017

--- a/.ci_support/migrations/aws_c_io01314.yaml
+++ b/.ci_support/migrations/aws_c_io01314.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_io:
+- 0.13.14
+migrator_ts: 1673680924.2678478

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,9 +1,9 @@
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 c_compiler:
 - vs2019
 channel_sources:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,11 @@
-{% set name = "aws-c-mqtt" %}
 {% set version = "0.8.6" %}
 
 package:
-  name: {{ name|lower }}
+  name: aws-c-mqtt
   version: {{ version }}
 
 source:
-  url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://github.com/awslabs/aws-c-mqtt/archive/v{{ version }}.tar.gz
   sha256: f3ba475f52b9477fd9cfa06d69679e213fd0bed7a2fb16bd10845f0b5437655e
   patches:
     # see https://github.com/awslabs/aws-c-mqtt/issues/257

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0001-increase-timeouts-for-two-mqtt5_client_tests.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-c-mqtt", max_pin="x.x.x") }}
 


### PR DESCRIPTION
Migrators racing + being pinned to old versions not being ABI-migrated anymore in other parts of the aws-* stack = conflict